### PR TITLE
🐛 Remove 'undefined' from logs when only message is provided

### DIFF
--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -5,15 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2020-11-02
+
+### Fixed
+- Removed `undefined` from logs when only message provided.
+
 ## [1.2.0] - 2020-10-30
 
-## Changed
+### Changed
 
-- Added additiional parameters logging
+- Added additional parameters logging.
 
 ## [1.1.0] - 2020-07-26
 
-## Changed
+### Changed
 
 - Updated `winston` to `3.3.3`.
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tree-house/logger",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Simple and fast JSON logging library for node.js services.",
   "keywords": [
     "NodeJS",

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -13,12 +13,9 @@ const LEVEL_EMOJI: Record<string, string> = {
   default: '🤷‍♂️',
 };
 
-const getWinstonParams = (info: TransformableInfo): unknown[] => {
-  // Winston adds all parameters to 'splat' property which is accessible only by Symbol[splat]
-  const paramsIn = info[Symbol.for('splat') as any];
-  return paramsIn instanceof Array ? paramsIn : [paramsIn];
-};
-
+/**
+ * Returns emoji format based on level.
+ */
 const emojiLevelFormat = format(
   (info: TransformableInfo): TransformableInfo => {
     const { level } = info;
@@ -27,9 +24,28 @@ const emojiLevelFormat = format(
   },
 );
 
+/**
+ * Extracts parameters from winston.
+ */
+const getWinstonParams = (info: TransformableInfo): any[] | undefined => {
+  // Winston adds all parameters to 'splat' property which is accessible only by Symbol[splat]
+  return info[Symbol.for('splat') as any];
+};
+
+/**
+ * Returns stringified parameters, split by new line.
+ * Returns undefined if parameters are undefined.
+ */
+const stringifyParams = (params: any[] | undefined): string[] | undefined =>
+  params === undefined ? params : params.map((v: any) => `${EOL}${stringify(v)}`);
+
+/**
+ * Formats parameters by splitting them into multiple lines.
+ */
 const paramsFormat = format(
   (info: TransformableInfo): TransformableInfo => {
-    const params = getWinstonParams(info).map((v: unknown) => EOL + stringify(v));
+    const winstonParams = getWinstonParams(info);
+    const params = stringifyParams(winstonParams);
     return { ...info, params };
   },
 );

--- a/packages/logger/src/tests/logger.ts
+++ b/packages/logger/src/tests/logger.ts
@@ -36,8 +36,27 @@ describe('Basic logger test', () => {
     expect(consoleSpy).toBeCalledTimes(1);
   });
 
+  it('Should output only one line', () => {
+    logger.error(message);
+    expect(consoleSpy).toHaveBeenCalledWith<[string]>(
+      expect.stringMatching(new RegExp(`.*${message}\n$`)), // cut off color string
+    );
+  });
+
+  it('Should output multiple line', () => {
+    logger.error(message, undefined);
+    expect(consoleSpy).toHaveBeenCalledWith<[string]>(
+      expect.stringMatching(new RegExp(`.*${message}\nundefined\n$`)), // cut off color string
+    );
+  });
+
   it('Should output formatted warn message to console', () => {
     logger.warn(message, params[0], params[1]);
+    expect(consoleSpy).toBeCalledTimes(1);
+  });
+
+  it('Should output formatted error message to console two', () => {
+    logger.error(message);
     expect(consoleSpy).toBeCalledTimes(1);
   });
 });


### PR DESCRIPTION
When logging just message, logger outputs extra line with `undefined`, see screenshot:
![image](https://user-images.githubusercontent.com/10702288/97912594-00392680-1d1b-11eb-986b-b6298d51d62f.png)

When winston params are undefined we were converting them to `[undefined]`.