### PR TITLE
Fix tests for yarn 2

### DIFF
--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2021-03-04
+
+### Added
+
+- `setup` function to manually set name & version oof the service.
+
+
 ## [2.1.0] - 2021-01-30
 
 ### Changed

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -18,6 +18,26 @@ yarn add @tree-house/logger
 
 ## Usage
 
+### Setup
+
+Service name & version (required for GCP Error Reporting) are determined by:
+
+1. Environment variables `npm_package_name` and `npm_package_version`.
+2. The options passed into the `setup` function.
+
+The options passed into the `setup` function will override the values provided by the envionrment
+variables (if they were populated to begin with).
+
+To use the `setup` function to populate name & version of your service, add the following to your
+startup code before using `NSLogger`:
+
+```typescript
+import { setup } from '@tree-house/logger';
+
+// NOTE: Name & version should ideally be grabbed from `package.json`
+setup({ name: 'my-service', version: '1.2.3' })
+```
+
 ### Namespaces
 
 You can use this logger with or without namespaces - namespaces help during debugging & are logged to
@@ -55,11 +75,6 @@ NSlogger('my-namespace').error(
   },
 )
 ```
-
-### Service name & version
-
-Service name & version (required for GCP Error Reporting) are determined by environment variables
-`npm_package_name` and `npm_package_version`.
 
 ## Bugs
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tree-house/logger",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Simple and fast JSON logging library for node.js services.",
   "keywords": [
     "NodeJS",

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -64,3 +64,24 @@ export interface ILogger {
   info: (message: string, ...args: any[]) => void;
   debug: (message: string, ...args: any[]) => void;
 }
+
+export interface ISetupOptions {
+  // Name of the service
+  name: string;
+  // Version of the service
+  version: string;
+}
+
+/**
+ * Assigns service name & version to log entries.
+ * @param param0 - Name & version of the service to associate with log entries.
+ */
+export const setup = ({ name, version }: ISetupOptions) => {
+  Object.assign(instance.defaultMeta, {
+    ...instance.defaultMeta,
+    serviceContext: {
+      service: name,
+      version: `${version}-${ENV.nodeEnv}`,
+    },
+  });
+}

--- a/packages/logger/src/tests/logger.ts
+++ b/packages/logger/src/tests/logger.ts
@@ -68,7 +68,9 @@ describe('Basic logger test', () => {
   describe('LOG_FORMAT = json', () => {
     const getLogger = () => {
       process.env.LOG_FORMAT = 'json';
-      const { NSlogger } = require('..');
+      const { NSlogger, setup } = require('..');
+      setup({ name: '@tree-house/logger', version: '1.2.3' });
+
       return NSlogger('test');
     };
 


### PR DESCRIPTION
As mentioned in https://github.com/knor-el-snor/tree-house/pull/21#issuecomment-789444827, yarn 2.4.1 doesn't support `npm_package_version` or `npm_package_name`. This is a workaround - you can call the `setup` function to provide those values yourself