### PR TITLE
🐛 Fix logger namespaces

### DIFF
--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2021-05-19
+
+- Fixed initializing multiple logger instances with different namespaces.
+- Debug logs now get correctly logged to GCP logging.
+
 ## [2.2.0] - 2021-03-04
 
 ### Added

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tree-house/logger",
-  "version": "2.3.0-rc.2",
+  "version": "2.3.0",
   "description": "Simple and fast JSON logging library for node.js services.",
   "keywords": [
     "NodeJS",

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -4,7 +4,7 @@ import minimatch from 'minimatch';
 import { ENV } from './constants';
 import { paramsFormat, jsonFormat, simpleFormat } from './format';
 
-const instance: Logger = createLogger({
+const createLoggerInstance = (defaultMeta: { [key: string]: string; } = {}) => createLogger({
   level: ENV.logLevel,
   format: format.combine(
     format.timestamp({ alias: 'timestamp' }),
@@ -15,6 +15,7 @@ const instance: Logger = createLogger({
     serviceContext: {
       service: ENV.serviceName,
       version: `${ENV.serviceVersion}-${ENV.nodeEnv}`,
+      ...defaultMeta,
     },
   },
   transports: [
@@ -24,6 +25,8 @@ const instance: Logger = createLogger({
     }),
   ],
 });
+
+const instance: Logger = createLoggerInstance();
 
 export const logger: ILogger = {
   info: instance.info.bind(instance),
@@ -57,16 +60,16 @@ const shouldLogDebug = (namespace): Boolean => {
 export const NSlogger = (namespace: string = ''): ILogger => {
   const newNamespace = getNamespace(namespace);
 
-  Object.assign(instance.defaultMeta, {
+  const loggerInstance = createLoggerInstance({
     ...instance.defaultMeta,
     namespace: newNamespace,
   });
 
   return {
-    info: instance.info.bind(instance),
-    warn: instance.warn.bind(instance),
-    debug: shouldLogDebug(newNamespace) ? instance.debug.bind(instance) : () => {},
-    error: instance.error.bind(instance),
+    info: loggerInstance.info.bind(loggerInstance),
+    warn: loggerInstance.warn.bind(loggerInstance),
+    debug: shouldLogDebug(newNamespace) ? loggerInstance.debug.bind(loggerInstance) : () => {},
+    error: loggerInstance.error.bind(loggerInstance),
   };
 };
 


### PR DESCRIPTION
Initializing multiple instances of logger with different namespaces wasn't previously possible since we're re-using the same logger instance everywhere. The logger that was initialized last was always "winning" in terms of which namespace logs show up under