### PR TITLE
🐛 Allow slashes in debug logs

### DIFF
--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2021-07-08
+
+### Fixed
+
+- Allow `/`s in debug log namespaces.
+
+### Added
+
+- Allow multiple debug filters as a comma-separated string
+- Allow skipping specific debug logs by using `-`.
+
 ## [2.3.1] - 2021-06-03
 
 ### Fixed

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -25,7 +25,7 @@ Service name & version (required for GCP Error Reporting) are determined by:
 1. Environment variables `npm_package_name` and `npm_package_version`.
 2. The options passed into the `setup` function.
 
-The options passed into the `setup` function will override the values provided by the envionrment
+The options passed into the `setup` function will override the values provided by the environment
 variables (if they were populated to begin with).
 
 To use the `setup` function to populate name & version of your service, add the following to your
@@ -49,6 +49,16 @@ import { NSLogger, logger } from '@tree-house/logger';
 NSLogger('my-namespace').info('tree house logger');
 logger.info('tree house logger');
 ```
+
+### Debug
+
+You can enable/disable all/some debug logs based on `LOG_LEVEL` and `DEBUG` environment variables.
+If you set `LOG_LEVEL` to `debug` (the default), you can use the `DEBUG` environment variable to
+enable these based on comma-delimited names.
+
+To skip a specific namespace: `DEBUG=*,-not_this`
+To log a specific namespace: `DEBUG=this:*`
+To log multiple namespaces: `DEBUG=this:*,that:*`
 
 ### Errors
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -40,7 +40,6 @@
   },
   "dependencies": {
     "json-stringify-safe": "5.0.1",
-    "minimatch": "^3.0.4",
     "winston": "3.3.3"
   },
   "devDependencies": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tree-house/logger",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Simple and fast JSON logging library for node.js services.",
   "keywords": [
     "NodeJS",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2165,7 +2165,6 @@ __metadata:
     husky: 6.0.0
     jest: 27.0.1
     json-stringify-safe: 5.0.1
-    minimatch: ^3.0.4
     rimraf: 3.0.2
     ts-jest: 27.0.1
     tslint: 6.1.3


### PR DESCRIPTION
Having `/` in namespaces would prevent the debug logs from showing up even though `DEBUG` environment variable is set correctly.


This fixes it, and adds support for multiple filters & skipping specific logs.
Borrowed from https://github.com/visionmedia/debug/blob/d177f2bc36d3b8b8e9b1b006727ef5e04f98eac7/src/common.js#L162