### PR TITLE
🐛 Propagate error details during parsing

### DIFF
--- a/packages/errors/src/lib/parser.ts
+++ b/packages/errors/src/lib/parser.ts
@@ -37,7 +37,7 @@ export const isApiError = (err: ApiError | any, type?: ErrorType): err is ApiErr
  */
 export function parseErrors(error: any = {}, translatorOptions?: TranslatorOptions): ParsedError {
   const metaData: any = {};
-  let parsedError = new ApiError(errorDefaults.DEFAULT_HTTP_CODE, errorDefaults.DEFAULT_ERROR); // Default error
+  let parsedError = new ApiError(errorDefaults.DEFAULT_HTTP_CODE, errorDefaults.DEFAULT_ERROR, error); // Default error
 
   // Other errors
   if (error instanceof Error) {


### PR DESCRIPTION
This allows us to preserve the original error details.

Tests need to be written