### PR TITLE
Add `hideMeta` to hide error stack from parsed errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-house",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": "Shop Bonsai<developers@shopbonsai.ca>",
   "private": true,
   "scripts": {

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] - 2023-01-09
+
+### Added
+
+- Added `hideMeta` option to hide error stack from parsed errors
+
 ## [2.0.0] - 2021-10-02
 
 ### Breaking

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tree-house/errors",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "NodeJS default error definitions with an error parser utility function",
   "keywords": [
     "NodeJS",

--- a/packages/errors/src/lib/parser.ts
+++ b/packages/errors/src/lib/parser.ts
@@ -32,10 +32,10 @@ export const isApiError = (err: ApiError | any, type?: ErrorType): err is ApiErr
 
 /**
  * Parse errors
- * @param {String} error
- * @param {Object} translatorOptions
+ * @param {String} error - Error to parse.
+ * @param {Object} options - Options for parsing.
  */
-export function parseErrors(error: any = {}, translatorOptions?: TranslatorOptions): ParsedError {
+export function parseErrors(error: any = {}, options: ParserOptions = {}): ParsedError {
   const metaData: any = {};
   let parsedError = new ApiError(errorDefaults.DEFAULT_HTTP_CODE, errorDefaults.DEFAULT_ERROR); // Default error
 
@@ -64,10 +64,12 @@ export function parseErrors(error: any = {}, translatorOptions?: TranslatorOptio
   if (isApiError(error)) {
     let translatedMessage = error.message;
 
-    if (translatorOptions && error.i18n) {
-      const translator = getTranslator(translatorOptions.path, translatorOptions.defaultLocale);
+    const { path: languagePath, defaultLocale, language } = options;
+
+    if (languagePath != undefined && error.i18n) {
+      const translator = getTranslator(languagePath, defaultLocale);
       try {
-        translatedMessage = translator.translate(error.i18n, translatorOptions.language) || error.message;
+        translatedMessage = translator.translate(error.i18n, language) || error.message;
       } catch (_error) {
         // If language file was not found set text to default message
         translatedMessage = error.message;
@@ -83,6 +85,8 @@ export function parseErrors(error: any = {}, translatorOptions?: TranslatorOptio
     parsedError = Object.assign({}, error, { message: translatedMessage });
   }
 
+  const { hideMeta } = options
+
   // Return object easy to use for serialisation
   return {
     id: parsedError.id,
@@ -90,7 +94,7 @@ export function parseErrors(error: any = {}, translatorOptions?: TranslatorOptio
     code: parsedError.code,
     title: parsedError.message,
     detail: parsedError.detail || parsedError.message,
-    meta: Object.keys(metaData).length !== 0 ? metaData : undefined,
+    meta: Boolean(hideMeta) === false && Object.keys(metaData).length !== 0 ? metaData : undefined,
   };
 }
 
@@ -119,9 +123,13 @@ export function parseJsonErrors(response: any): ApiError[] {
 
 // Interfaces
 export interface TranslatorOptions {
-  path: string;
+  path?: string;
   defaultLocale?: string;
   language?: string;
+}
+
+export interface ParserOptions extends TranslatorOptions {
+  hideMeta?: boolean;
 }
 
 export interface ParsedError {

--- a/packages/errors/src/lib/parser.ts
+++ b/packages/errors/src/lib/parser.ts
@@ -66,7 +66,7 @@ export function parseErrors(error: any = {}, options: ParserOptions = {}): Parse
 
     const { path: languagePath, defaultLocale, language } = options;
 
-    if (languagePath != undefined && error.i18n) {
+    if (languagePath != null && error.i18n) {
       const translator = getTranslator(languagePath, defaultLocale);
       try {
         translatedMessage = translator.translate(error.i18n, language) || error.message;
@@ -85,7 +85,7 @@ export function parseErrors(error: any = {}, options: ParserOptions = {}): Parse
     parsedError = Object.assign({}, error, { message: translatedMessage });
   }
 
-  const { hideMeta } = options
+  const { hideMeta } = options;
 
   // Return object easy to use for serialisation
   return {
@@ -94,7 +94,7 @@ export function parseErrors(error: any = {}, options: ParserOptions = {}): Parse
     code: parsedError.code,
     title: parsedError.message,
     detail: parsedError.detail || parsedError.message,
-    meta: Boolean(hideMeta) === false && Object.keys(metaData).length !== 0 ? metaData : undefined,
+    meta: !Boolean(hideMeta) && Object.keys(metaData).length !== 0 ? metaData : undefined,
   };
 }
 

--- a/packages/errors/tests/parser.test.ts
+++ b/packages/errors/tests/parser.test.ts
@@ -158,9 +158,14 @@ describe('errorParser', () => {
       });
     });
 
-    it('Should have `meta` field with the error stack', () => {
+    it.each([
+      [undefined, false],
+      [{ hideMeta: undefined }, false],
+      [{ hideMeta: true }, true],
+      [{ hideMeta: false }, false],
+    ])('Should correctly generate `meta` field with options `%o`', (options, shouldRemove) => {
       const error = new BadRequestError(errors.INVALID_INPUT);
-      const parsedError = parseErrors(error);
+      const parsedError = parseErrors(error, options);
 
       expect(parsedError).toMatchObject({
         id: expect.any(String),
@@ -168,22 +173,11 @@ describe('errorParser', () => {
         code: errors.INVALID_INPUT.code,
         title: errors.INVALID_INPUT.message,
         detail: errors.INVALID_INPUT.message,
-        meta: {
-          stack: safeJsonStringify(error.stack as any),
-        }
-      });
-    });
-
-    it('Should not have `meta` field with the error stack when `hideMeta: true`', () => {
-      const error = new BadRequestError(errors.INVALID_INPUT);
-      const parsedError = parseErrors(error, { hideMeta: true });
-
-      expect(parsedError).toMatchObject({
-        id: expect.any(String),
-        status: httpStatus.BAD_REQUEST,
-        code: errors.INVALID_INPUT.code,
-        title: errors.INVALID_INPUT.message,
-        detail: errors.INVALID_INPUT.message,
+        ...(shouldRemove ? undefined : {
+          meta: {
+            stack: safeJsonStringify(error.stack as any),
+          },
+        })
       });
     });
 

--- a/packages/errors/tests/parser.test.ts
+++ b/packages/errors/tests/parser.test.ts
@@ -14,6 +14,7 @@ import {
   ForbiddenError,
 } from '../src';
 import { errorDefaults } from '../src/config/defaults.config';
+import safeJsonStringify from 'safe-json-stringify';
 
 describe('errorParser', () => {
   const defaultError = new ApiError(errorDefaults.DEFAULT_HTTP_CODE, errorDefaults.DEFAULT_ERROR);
@@ -66,7 +67,7 @@ describe('errorParser', () => {
   });
 
   describe('Predefined Api errors', () => {
-    it('Should succesfully parse default ApiError with i18n', () => {
+    it('Should successfully parse default ApiError with i18n', () => {
       const errorTranslation = 'English translation';
       translateMock.mockReturnValue(errorTranslation);
 
@@ -86,7 +87,7 @@ describe('errorParser', () => {
       expect(translateMock).toHaveBeenCalledTimes(1);
     });
 
-    it('Should succesfully parse default ApiError without an i18n key', () => {
+    it('Should successfully parse default ApiError without an i18n key', () => {
       expect.assertions(1);
       try {
         throw new ApiError(httpStatus.BAD_REQUEST, errors.INVALID_INPUT);
@@ -102,7 +103,7 @@ describe('errorParser', () => {
       }
     });
 
-    it('Should succesfully parse default ApiError with default message when language is not available', () => {
+    it('Should successfully parse default ApiError with default message when language is not available', () => {
       expect.assertions(1);
       try {
         throw new BadRequestError(errors.INVALID_INPUT);
@@ -118,7 +119,7 @@ describe('errorParser', () => {
       }
     });
 
-    it('Should succesfully parse default ApiError for Dutch translation', () => {
+    it('Should successfully parse default ApiError for Dutch translation', () => {
       const errorTranslation = 'Nederlands vertaling';
       translateMock.mockReturnValue(errorTranslation);
 
@@ -148,6 +149,35 @@ describe('errorParser', () => {
         path: '',
         language: 'du',
       });
+      expect(parsedError).toMatchObject({
+        id: expect.any(String),
+        status: httpStatus.BAD_REQUEST,
+        code: errors.INVALID_INPUT.code,
+        title: errors.INVALID_INPUT.message,
+        detail: errors.INVALID_INPUT.message,
+      });
+    });
+
+    it('Should have `meta` field with the error stack', () => {
+      const error = new BadRequestError(errors.INVALID_INPUT);
+      const parsedError = parseErrors(error);
+
+      expect(parsedError).toMatchObject({
+        id: expect.any(String),
+        status: httpStatus.BAD_REQUEST,
+        code: errors.INVALID_INPUT.code,
+        title: errors.INVALID_INPUT.message,
+        detail: errors.INVALID_INPUT.message,
+        meta: {
+          stack: safeJsonStringify(error.stack as any),
+        }
+      });
+    });
+
+    it('Should not have `meta` field with the error stack when `hideMeta: true`', () => {
+      const error = new BadRequestError(errors.INVALID_INPUT);
+      const parsedError = parseErrors(error, { hideMeta: true });
+
       expect(parsedError).toMatchObject({
         id: expect.any(String),
         status: httpStatus.BAD_REQUEST,
@@ -259,7 +289,7 @@ describe('errorParser', () => {
   });
 
   describe('parseJsonErrors', () => {
-    it('Should succesfully return parsed errors', () => {
+    it('Should successfully return parsed errors', () => {
       const result = parseJsonErrors({
         errors: [
           {
@@ -289,7 +319,7 @@ describe('errorParser', () => {
       });
     });
 
-    it('Should succesfully return parsed errors with empty meta', () => {
+    it('Should successfully return parsed errors with empty meta', () => {
       const result = parseJsonErrors({
         errors: [
           {
@@ -316,7 +346,7 @@ describe('errorParser', () => {
       });
     });
 
-    it('Should succesfully return parsed errors without meta', () => {
+    it('Should successfully return parsed errors without meta', () => {
       const result = parseJsonErrors({
         errors: [
           {


### PR DESCRIPTION
You can now provide `hideMeta` as an option to hide the error stack in parsed errors