### PR TITLE
✨ Add the ability to skip serialization in tree-house-serializer

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v3

--- a/packages/serializer/CHANGELOG.md
+++ b/packages/serializer/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2023-11- 13
+
+### Breaking
+
+- Dropped support for Node 16!
+
+### Changes
+
+- Add ability to pass `skip` as an option to allow raw data being returned without serialization. Can be useful during migration when not all serializers are set up.
+
+## [2.4.0] - 2021-10-02
+
+### Breaking
+
+- Dropped support for Node 10!
+
 ## [2.0.0] - 2021-10-02
 
 ### Breaking

--- a/packages/serializer/README.md
+++ b/packages/serializer/README.md
@@ -49,6 +49,7 @@ Options:
 - `camelCase`: Converts keys to camelCase
 - `snake_case`: Converts keys to snake_case
 - `kebab-case`: Converts keys to kebab-case
+- `skipSerialization`: Allows serialization to be skipped. Should only be used during development or pre-migration to a serializer
 
 #### Returns
 

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tree-house/serializer",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Json de/serialization made for consistency",
   "keywords": [
     "NodeJS",
@@ -54,6 +54,6 @@
     "typescript": "5.0.4"
   },
   "engines": {
-    "node": ">=16.x"
+    "node": ">=18.x"
   }
 }

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tree-house/serializer",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Json de/serialization made for consistency",
   "keywords": [
     "NodeJS",

--- a/packages/serializer/src/interfaces.ts
+++ b/packages/serializer/src/interfaces.ts
@@ -7,6 +7,7 @@ export interface ISerializerConfig {
 
 export interface ISerializerOptions {
   case?: ICasing;
+  skipSerialization?: boolean;
 }
 
 export interface ISerializedResponse {

--- a/packages/serializer/src/interfaces.ts
+++ b/packages/serializer/src/interfaces.ts
@@ -7,7 +7,7 @@ export interface ISerializerConfig {
 
 export interface ISerializerOptions {
   case?: ICasing;
-  skipSerialization?: boolean;
+  skip?: boolean;
 }
 
 export interface ISerializedResponse {

--- a/packages/serializer/src/serializer.ts
+++ b/packages/serializer/src/serializer.ts
@@ -27,7 +27,7 @@ export class Serializer {
 
   async serialize(data: any, dataSetConfig: IMeta = {}): Promise<ISerializedResponse> {
     // Set resource to unchanged if `skip` is true
-    const resource = this.options.skip ? 'unchanged': this.resource;
+    const resource = this.options.skip ? 'unchanged' : this.resource;
 
     // Skip data serialization if `skip` is true
     const serializedData = this.options.skip ? data : await constructData(data, this.config, this.options);

--- a/packages/serializer/src/serializer.ts
+++ b/packages/serializer/src/serializer.ts
@@ -26,9 +26,15 @@ export class Serializer {
   }
 
   async serialize(data: any, dataSetConfig: IMeta = {}): Promise<ISerializedResponse> {
+    // Set resource to unchanged if `skip` is true
+    const resource = this.options.skip ? 'unchanged': this.resource;
+
+    // Skip data serialization if `skip` is true
+    const serializedData = this.options.skip ? data : await constructData(data, this.config, this.options);
+
     return {
-      meta: constructMeta(data, this.resource, dataSetConfig),
-      data: await constructData(data, this.config, this.options),
+      meta: constructMeta(data, resource, dataSetConfig),
+      data: serializedData,
     };
   }
 }

--- a/packages/serializer/src/utils/data-construction.util.ts
+++ b/packages/serializer/src/utils/data-construction.util.ts
@@ -74,6 +74,15 @@ export const constructData = async (data: any, customConfig: ISerializerConfig =
 
   const config = { ...defaultConfig, ...customConfig };
 
+  // Allows serialization to be skipped
+  // Should only be used during development or pre-migration to a serializer
+  if(options.skipSerialization) {
+    if(config.attributes.length > 0) {
+      console.debug('Skipping serialization of attributes although defined (uses skipSerialization option)', config.attributes);
+    }
+    return data;
+  }
+
   // if the dataset is an array
   if (isArray(data)) {
     return await Promise.all(data.map(async item => await constructData(item, config, options)));

--- a/packages/serializer/src/utils/data-construction.util.ts
+++ b/packages/serializer/src/utils/data-construction.util.ts
@@ -74,15 +74,6 @@ export const constructData = async (data: any, customConfig: ISerializerConfig =
 
   const config = { ...defaultConfig, ...customConfig };
 
-  // Allows serialization to be skipped
-  // Should only be used during development or pre-migration to a serializer
-  if(options.skipSerialization) {
-    if(config.attributes.length > 0) {
-      console.debug('Skipping serialization of attributes although defined (uses skipSerialization option)', config.attributes);
-    }
-    return data;
-  }
-
   // if the dataset is an array
   if (isArray(data)) {
     return await Promise.all(data.map(async item => await constructData(item, config, options)));

--- a/packages/serializer/tests/serializer.test.ts
+++ b/packages/serializer/tests/serializer.test.ts
@@ -72,7 +72,7 @@ describe('Serializer multiple resource', () => {
 
     const userSerializer = new Serializer('user', {
       attributes: [],
-    }, { skipSerialization: true });
+    }, { skip: true });
 
     const result = await userSerializer.serialize(rawData, {
       totalCount: 99,
@@ -83,7 +83,7 @@ describe('Serializer multiple resource', () => {
     const { data, meta } = result;
     expect(data).toEqual(rawData);
     expect(meta.count).toEqual(2);
-    expect(meta.type).toEqual('user');
+    expect(meta.type).toEqual('unchanged');
     expect(meta.totalCount).toEqual(99);
     expect(meta.planet).toEqual('earth');
   })

--- a/packages/serializer/tests/serializer.test.ts
+++ b/packages/serializer/tests/serializer.test.ts
@@ -63,4 +63,28 @@ describe('Serializer multiple resource', () => {
     expect(meta.totalCount).toEqual(99);
     expect(meta.planet).toEqual('earth');
   });
+
+  test('Should skip serialization entirely if skipSerialization is true', async () => {
+    const rawData = [
+      { firstName: 'John', lastName: 'Doe' },
+      { firstName: 'Jane', lastName: 'Doe' },
+    ];
+
+    const userSerializer = new Serializer('user', {
+      attributes: [],
+    }, { skipSerialization: true });
+
+    const result = await userSerializer.serialize(rawData, {
+      totalCount: 99,
+      type: 'definitely_lizards',
+      planet: 'earth',
+    });
+
+    const { data, meta } = result;
+    expect(data).toEqual(rawData);
+    expect(meta.count).toEqual(2);
+    expect(meta.type).toEqual('user');
+    expect(meta.totalCount).toEqual(99);
+    expect(meta.planet).toEqual('earth');
+  })
 });


### PR DESCRIPTION
We wish to ensure a serializer is set up all the time as a requirement in services, but given sometimes migration is still happening, it should be temporarily possible to skip serialization